### PR TITLE
Added unit test to test getting random frames from frameVector.

### DIFF
--- a/DisplayImage/DisplayImage.h
+++ b/DisplayImage/DisplayImage.h
@@ -1,0 +1,20 @@
+/*
+ * DisplayImage.h
+ *
+ *  Created on: Jun 9, 2016
+ *      Author: Bones
+ */
+
+#ifndef DISPLAYIMAGE_H_
+#define DISPLAYIMAGE_H_
+#include<vector>
+#include<opencv/cxcore.h>
+#include<opencv/cv.h>
+#include<opencv/highgui.h>
+typedef struct FrameDeck
+{
+	std::vector<IplImage *> frameVector;
+	double fps;
+} FrameDeck;
+FrameDeck queryAllFrames( const char * filename );
+#endif /* DISPLAYIMAGE_H_ */

--- a/DisplayImage/src/DisplayImage.cpp
+++ b/DisplayImage/src/DisplayImage.cpp
@@ -1,18 +1,14 @@
-#include<opencv/cvaux.h>
-#include<opencv/highgui.h>
-#include<opencv/cxcore.h>
-#include<opencv/cv.h>
-
 
 #include<stdio.h>
 #include<stdlib.h>
-#include <vector>
 #define OUT stdout
 
+#include<DisplayImage.h>
 using namespace std;
 int sliderPosition = 0;
 const char * windowName = "windowExample";
-vector<IplImage *> frameVector;
+
+FrameDeck frames;
 
 char * getArguments(int argc, char * argv[])
 {
@@ -26,8 +22,7 @@ char * getArguments(int argc, char * argv[])
 		int i;
 		fprintf( OUT, "Ignoring the following arguments: " );
 		for( i = 2; i < argc; i++ )
-		{
-			fprintf( OUT, "%s ", argv[i] );
+		{			fprintf( OUT, "%s ", argv[i] );
 		}
 		fprintf( OUT, "\n" );
 	}
@@ -35,14 +30,15 @@ char * getArguments(int argc, char * argv[])
 }
 
 
-vector<IplImage *> queryAllFrames( const char * filename )
+FrameDeck queryAllFrames( const char * filename )
 {
 	CvCapture * capture = cvCaptureFromFile( filename );
 	vector<IplImage *> frames;
+	FrameDeck j;
 	if( capture == NULL )
 	{
 		fprintf( OUT, "Could not open the file\n" );
-		return frames;
+		return j;
 	}
 	IplImage * temp = cvQueryFrame( capture );
 	while( temp != NULL)
@@ -50,26 +46,36 @@ vector<IplImage *> queryAllFrames( const char * filename )
 		frames.push_back( cvCloneImage( temp ) );
 		temp = cvQueryFrame( capture );
 	}
+	j.fps = 0;
+	j.fps = cvGetCaptureProperty( capture, CV_CAP_PROP_FPS );
+	if( !j.fps ) j.fps = 50;
+	j.frameVector = frames;
 	cvReleaseCapture( &capture );
-	return frames;
+
+	return j;
 }
 
-int displayFramesInWindow( vector<IplImage *> frames, const char * windowName )
+int displayFramesInWindow( FrameDeck frames, const char * windowName )
 {
 	unsigned int i;
-	for( i = 0; i < frames.size(); i++ )
+	for( i = 0; i < frames.frameVector.size(); i++ )
 	{
-		cvShowImage( windowName, frames[i] );
-		cvWaitKey( 20 );
+		cvShowImage( windowName, frames.frameVector[i] );
+		cvWaitKey( 1000 / frames.fps );
 	}
 	return 0;
 }
 
+/*int saveVideo( char * filename, FrameDeck frames )
+{
+
+}*/
+
 void updateFrame( int position )
 {
-	cvShowImage( windowName, frameVector[position] );
+	cvShowImage( windowName, frames.frameVector[position] );
 }
-
+/*
 int main(int argc, char * argv[])
 {
 	char * filename = getArguments( argc, argv );
@@ -79,9 +85,9 @@ int main(int argc, char * argv[])
 
 	cvNamedWindow( windowName, CV_WINDOW_AUTOSIZE);
 
-	frameVector = queryAllFrames( filename );
+	frames = queryAllFrames( filename );
 
-	cvCreateTrackbar( trackbarName, windowName, &sliderPosition, frameVector.size() - 1, (CvTrackbarCallback) updateFrame );
+	cvCreateTrackbar( trackbarName, windowName, &sliderPosition, frames.frameVector.size() - 1, (CvTrackbarCallback) updateFrame );
 	int key;
 	while( true )
 	{
@@ -93,15 +99,15 @@ int main(int argc, char * argv[])
 		}
 		else if( key == 'l' ) // right
 		{
-			if( sliderPosition < frameVector.size() - 1 )
+			if( sliderPosition < frames.frameVector.size() - 1 )
 				cvSetTrackbarPos( trackbarName, windowName, sliderPosition + 1 );
 		}
 		else if( key == 'i' ) // up
 		{
-			if( sliderPosition < frameVector.size() - 10 )
+			if( sliderPosition < frames.frameVector.size() - 10 )
 				cvSetTrackbarPos( trackbarName, windowName, sliderPosition + 10 );
 			else
-				cvSetTrackbarPos( trackbarName, windowName, frameVector.size() - 1 );
+				cvSetTrackbarPos( trackbarName, windowName, frames.frameVector.size() - 1 );
 		}
 		else if( key == 'k' ) // down
 		{
@@ -118,5 +124,6 @@ int main(int argc, char * argv[])
 
 	return 0;
 }
+*/
 
 

--- a/DisplayImage/test/gtest_main.cpp
+++ b/DisplayImage/test/gtest_main.cpp
@@ -1,0 +1,9 @@
+// gtest_main.cpp
+#include <stdio.h>
+#include <gtest/gtest.h>
+
+GTEST_API_ int main(int argc, char **argv) {
+  printf("Running main() from gtest_main.cc\n");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/DisplayImage/test/test_displayImage.cpp
+++ b/DisplayImage/test/test_displayImage.cpp
@@ -1,0 +1,57 @@
+/*
+ * test_displayImage.cpp
+ *
+ *  Created on: Jun 9, 2016
+ *      Author: Bones
+ */
+#include <DisplayImage.h>
+#include <gtest/gtest.h>
+#include <ctime>
+#define MIN_FRAME 0
+#define MAX_FRAME 163
+#define numberOfTests 5
+
+
+
+using namespace std;
+const char * testFile = "http://techslides.com/demos/sample-videos/small.ogv";
+int sameImage( IplImage * , IplImage *  );
+
+TEST(GetFramesTest, positive){
+	FrameDeck framesTest = queryAllFrames( testFile );
+	CvCapture * testCapture = cvCaptureFromFile( testFile );
+	IplImage * testFramesIpl[numberOfTests];
+	int testFrames[numberOfTests];
+	int i;
+
+	cout << "Frames under test: " << endl;
+	for( i = 0; i < numberOfTests; i++ )
+	{
+		testFrames[i] = rand() % MAX_FRAME;
+		cout << testFrames[i] << endl;
+	}
+	for( i = 0; i < numberOfTests; i++ )
+	{
+		cvSetCaptureProperty( testCapture, CV_CAP_PROP_POS_FRAMES, testFrames[i]);
+		testFramesIpl[i] = cvQueryFrame( testCapture );
+		ASSERT_TRUE( !sameImage( framesTest.frameVector[testFrames[i]], testFramesIpl[i]) );
+	}
+}
+
+int sameImage( IplImage * first, IplImage * second )
+{
+	int i, lengthOfArray1, lengthOfArray2;
+	lengthOfArray1 = first->nChannels * first->width * first->height;
+	lengthOfArray2 = second->nChannels * second->width * second->height;
+	if( lengthOfArray1 != lengthOfArray2 ) return 1;
+
+	for( i = 0; i < lengthOfArray1; i++ )
+	{
+		if( first->imageData[i] != second->imageData[i] ) return 1;
+	}
+
+	return 0; // essentially the same frame
+}
+
+
+


### PR DESCRIPTION
Moves libraries to header file (DisplayImage.h)
Adds gtest tests, with help function to compare two frames (pixel by pixel, nothing else is compared).
Leaves possibility for profiling between frames retrieval and cvQueryFrame + cvSetCaptureProperty. In some tests, requesting a frame takes as long as 4 seconds, while frame retrieval from the vector takes an unmeasurably small amount of time (~0 seconds) - clearly best method to use.

This unit test will keep code from breaking during refactoring - at least queryAllFrames
